### PR TITLE
Remove moved config files

### DIFF
--- a/stryker/configuration/angular.md
+++ b/stryker/configuration/angular.md
@@ -1,3 +1,0 @@
-# Moved
-
-Moved to [Guides](../guides/angular.md)

--- a/stryker/configuration/react.md
+++ b/stryker/configuration/react.md
@@ -1,3 +1,0 @@
-# Moved
-
-Moved to [Guides](../guides/react.md)


### PR DESCRIPTION
Based on the current analytics, most trafic goes to the guides folder. I personally always click on the configuration folder out of habit. Let's remove the old configuration files.