### PR TITLE
Typo fix: "a" in scala getting started

### DIFF
--- a/stryker4s/getting-started.md
+++ b/stryker4s/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-Stryker4s is mutation testing framework for Scala. It allows you to test your tests by temporarily inserting bugs.
+Stryker4s is a mutation testing framework for Scala. It allows you to test your tests by temporarily inserting bugs.
 
 Currently, the only way to get started with Stryker4s is to use the [command test-runner](https://github.com/stryker-mutator/stryker4s/blob/master/docs/CONFIGURATION.md#test-runner).
  The `command` test-runner is build tool agnostic and can be used by every build tool that supports Scala. For example, the `sbt test` and `mvn test` both run the specified unit tests in your codebase. This will put you as a user in full control! 


### PR DESCRIPTION
I promise this isn't _just_ for Hacktoberfest 😂