### PR TITLE
Fix incorrect Stryker4s quickstart documentation

### DIFF
--- a/stryker4s/getting-started.md
+++ b/stryker4s/getting-started.md
@@ -18,6 +18,7 @@ You will have to edit the `base-dir` to match the codebase you want to mutate.
 Also, make sure the `test-runner` is configured with the commands you need to run your unit tests.    
 ```conf
 stryker4s {
+    log-level=INFO
     mutate=[
         "**/main/scala/**/*.scala"
     ]

--- a/stryker4s/getting-started.md
+++ b/stryker4s/getting-started.md
@@ -12,21 +12,22 @@ To get started you need to clone the [Stryker4s repository](https://github.com/s
 
 ## Configuration
 
-After cloning the repository, create the `stryker4s.conf` file in the root of the Stryker4s repository. 
-The configuration below contains a good starting point to run Stryker4s with the command test-runner. You will have to edit the `base-dir` to match the codebase you want to mutate. Also, make sure the `test-runner` is configured with the commands you need to run your unit tests.
-
- ```hocon
+After cloning the repository, create a `stryker4s.conf` file in the root of the Stryker4s repository. 
+The configuration below shows all the default options Stryker4s uses. You can edit ones you want to change, or remove the ones that look good for your project. The default configuration will start a command test-runner for sbt. 
+You will have to edit the `base-dir` to match the codebase you want to mutate. 
+Also, make sure the `test-runner` is configured with the commands you need to run your unit tests.    
+```conf
 stryker4s {
-  files: [
-    "foo/bar/src/main/**/*.scala"
-  ]
-   base-dir: "/tmp/project"
-   log-level: INFO
-   test-runner: {
-    type=commandrunner
-    command: "sbt"
-    args: "test"
-  }
-   reporters: ["console"]
+    mutate=[
+        "**/main/scala/**/*.scala"
+    ]
+    reporters=[
+        console
+    ]
+    test-runner {
+        args=test
+        command=sbt
+        type=commandrunner
+    }
 }
 ```


### PR DESCRIPTION
Some documentation in the Stryker4s quickstart was a bit outdated. This fixes that