### PR TITLE
docs(angular): update Angular guide to Stryker 4

### DIFF
--- a/stryker/guides/angular.md
+++ b/stryker/guides/angular.md
@@ -38,7 +38,7 @@ module.exports = function (config) {
     mutator: 'typescript',
     testRunner: 'karma',
     karma: {
-      configFile: 'src/karma.conf.js',
+      configFile: 'karma.conf.js',
       projectType: 'angular-cli',
       config: {
         browsers: ['ChromeHeadless']

--- a/stryker/guides/angular.md
+++ b/stryker/guides/angular.md
@@ -8,7 +8,7 @@ This setup only works with @angular/cli 9.0.0 or higher. Are you using an older 
 
 ## Install
 
-Either install the Stryker CLI globally using `npm install --global stryker-cli`, use `npx -p stryker-cli` in front of every Stryker command.
+Either install the Stryker CLI globally using `npm install --global stryker-cli`, or use `npx` in front of every Stryker command.
 Install the Stryker packages using the command `stryker init`.
 
 Recommended other packages:

--- a/stryker/guides/angular.md
+++ b/stryker/guides/angular.md
@@ -48,8 +48,19 @@ We highly suggest using a headless browser when testing using Stryker.
   "concurrency_comment": "Recommended to use about half of your available cores when running stryker with angular",
   "coverageAnalysis": "perTest"
 }
-
 ```
+
+Consider adding the Stryker TypeScript checker to increase mutation testing performance and kill mutants that would result in compilation errors:
+1. Install `@stryker-mutator/typescript-checker` as a development dependency:
+   `npm install --save-dev @stryker-mutator/typescript-checker`
+1. Configure the TypeScript checker in `stryker.conf.json`:
+   ```json
+   {
+     "checkers": ["typescript"],
+     "tsconfigFile": "tsconfig.json"
+   }
+   ```
+   If you experience issues, try setting the `tsconfigFile` option to `tsconfig.app.json`.
 
 ### Run
 

--- a/stryker/guides/angular.md
+++ b/stryker/guides/angular.md
@@ -1,0 +1,56 @@
+# Angular
+
+Stryker 4.0 and higher supports Angular projects using the Angular CLI starting from @angular/cli v9.0.0. Are you using an older version? Then there are some tips later in this document.
+
+## @angular/cli 9.0.0 and higher
+
+This setup only works with @angular/cli 9.0.0 or higher. Are you using an older version of Angular? Then we highly suggest upgrading to at least version 9.0.0 of the cli. You can use the [Angular Update Guide](https://update.angular.io/) to help you with this. If it's not possible for you to upgrade your Angular version, please check out [the legacy guide for Stryker 3 and Angular CLI 6.1-8.2](./legacy/stryker-3/angular.md).
+
+## Install
+
+Either install the Stryker CLI globally using `npm install --global stryker-cli`, use `npx -p stryker-cli` in front of every Stryker command.
+Install the Stryker packages using the command `stryker init`.
+
+Recommended other packages:
+
+* @angular/cli 9.0.0 or higher
+* @angular-devkit/build-angular 0.900.0 or higher
+* karma 4.3.0 or higher
+* typescript 3.7.2 or higher
+
+### Configuration
+
+The `stryker init` command also creates a `stryker.conf.json` or `stryker.conf.js` configuration in your repository
+like the one below which is a good starting point for Angular projects.
+You may have to change some paths or config settings like the selected browsers.
+We highly suggest using a headless browser when testing using Stryker.
+
+```json
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "_comment": "This config was generated using a preset. Please see the handbook for more information: https://github.com/stryker-mutator/stryker-handbook/blob/master/stryker/guides/angular.md#angular",
+  "mutate": [
+    "src/**/*.ts",
+    "!src/**/*.spec.ts",
+    "!src/test.ts",
+    "!src/environments/*.ts"
+  ],
+  "testRunner": "karma",
+  "karma": {
+    "configFile": "karma.conf.js",
+    "projectType": "angular-cli",
+    "config": {
+      "browsers": ["ChromeHeadless"]
+    }
+  },
+  "reporters": ["progress", "clear-text", "html"],
+  "concurrency": 2,
+  "concurrency_comment": "Recommended to use about half of your available cores when running stryker with angular",
+  "coverageAnalysis": "perTest"
+}
+
+```
+
+### Run
+
+Run Stryker using `stryker run`.

--- a/stryker/guides/legacy/stryker-3/angular.md
+++ b/stryker/guides/legacy/stryker-3/angular.md
@@ -38,7 +38,7 @@ module.exports = function (config) {
     mutator: 'typescript',
     testRunner: 'karma',
     karma: {
-      configFile: 'karma.conf.js',
+      configFile: 'src/karma.conf.js',
       projectType: 'angular-cli',
       config: {
         browsers: ['ChromeHeadless']

--- a/stryker/guides/legacy/stryker-3/angular.md
+++ b/stryker/guides/legacy/stryker-3/angular.md
@@ -1,19 +1,19 @@
 # Angular
 
-Stryker supports Angular projects using the Angular CLI starting from @angular/cli v6.1.0. Are you using an older version? Then there are some tips later in this document.
+Stryker supports Angular projects using the Angular CLI between @angular/cli 6.1.0 and 8.3.29. Are you using an older version? Then there are some tips later in this document.
 
-## @angular/cli 6.1.0 and higher
+## @angular/cli 6.1.0-8.3.29
 
-This setup only works with @angular/cli 6.1.0 or higher. Are you using an older version of Angular? Then we highly suggest upgrading to at least version 6.1.0 of the cli. You can use the [Angular Update Guide](https://update.angular.io/) to help you with this. If it's not possible for you to upgrade your Angular version, please check out [this repo and its commits](https://github.com/nicojs/angular-stryker-example).
+This setup only works with @angular/cli 6.1.0-8.3.29. Are you using an older version of Angular? Then we highly suggest upgrading to at least version 6.1.0 of the cli. You can use the [Angular Update Guide](https://update.angular.io/) to help you with this. If it's not possible for you to upgrade your Angular version, please check out [this repo and its commits](https://github.com/nicojs/angular-stryker-example).
 
 ## Install
 
-Install the Stryker packages using this command: `npm i -D @stryker-mutator/core @stryker-mutator/karma-runner @stryker-mutator/typescript @stryker-mutator/html-reporter`
+Install the Stryker packages using this command: `npm i -D @stryker-mutator/core@3 @stryker-mutator/karma-runner@3 @stryker-mutator/typescript@3 @stryker-mutator/html-reporter@3`
 
 Recommended other packages:
 
-* @angular/cli 6.1.0 or higher
-* @angular-devkit/build-angular 0.7.2 or higher
+* @angular/cli 6.1.0-8.3.29
+* @angular-devkit/build-angular 0.7.2-0.803.29
 * karma 2.0.4 or higher
 * typescript 2.4.2 or higher
 


### PR DESCRIPTION
- Copy Angular 6.1-8.0 + Stryker 3 guide to legacy folder.
- Update Angular guide to Angular 9.0+ + Stryker 4.